### PR TITLE
feat(fails-first): Sort stopped Github action checks first

### DIFF
--- a/fails-first.user.js
+++ b/fails-first.user.js
@@ -48,7 +48,7 @@
             if (child.querySelector('.octicon-skip')) {
                 child.parentNode.removeChild(child);
                 skipped.push(child);
-            } else if (child.querySelector('.octicon-x')) {
+            } else if (child.querySelector('.octicon-x') || child.querySelector('.octicon-stop')) {
                 child.parentNode.removeChild(child);
                 fails.push(child);
             } else if (child.querySelector('.anim-rotate, .octicon-dot-fill')) {


### PR DESCRIPTION
Github action checks may timeout or be cancelled. Thus, we will need to consider them failures in case they're required checks.

Found this edge case from https://github.com/getsentry/getsentry/pull/7553

## Before

<img width="937" alt="Screen Shot 2022-05-25 at 6 13 18 PM" src="https://user-images.githubusercontent.com/139499/170379511-1b90f04e-9838-44b1-89b4-3c9b68d4f718.png">

## After

<img width="929" alt="Screen Shot 2022-05-25 at 6 13 30 PM" src="https://user-images.githubusercontent.com/139499/170379517-17ccbc0a-5c92-45be-95ab-42ab96593b8f.png">
