### PR TITLE
ref: upgrade actions/setup-python to avoid set-output deprecation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
     - uses: actions/cache@v3
       if: needs.files-changed.outputs.backend == 'true'
       with:


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos